### PR TITLE
Updated to use 3.0.0 Rabbitmq and latest Riak erlang Client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ DIST_DIR=dist
 EBIN_DIR=ebin
 INCLUDE_DIRS=include
 DEPS_DIR=deps
-DEPS ?= riakc protobuffs
+DEPS ?= riakc protobuffs riak_pb
 DEPS_EZ=$(foreach DEP, $(DEPS), $(DEPS_DIR)/$(DEP).ez)
 RABBITMQ_HOME ?= .
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ Riak Exchange
 
-Latest tagged version works with RabbitMQ 3.0.0 and Riak 1.0 (Riak Erlang client ver 1.3.1).
+Latest tagged version works with RabbitMQ 3.0.0 and Riak 1.2.1 (Riak Erlang client ver 1.3.1).
 
 This is a custom exchange type for RabbitMQ that will put any message sent to it into Riak. 
 By default, the Riak exchange will use your exchange name as the bucket name and your routing key as the Riak 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ Riak Exchange
 
-Latest tagged version works with RabbitMQ 2.8.1 and Riak 1.0 (Riak Erlang client ver 1.2.1).
+Latest tagged version works with RabbitMQ 3.0.0 and Riak 1.0 (Riak Erlang client ver 1.3.1).
 
 This is a custom exchange type for RabbitMQ that will put any message sent to it into Riak. 
 By default, the Riak exchange will use your exchange name as the bucket name and your routing key as the Riak 
@@ -38,9 +38,10 @@ Issuing...
 
 ...should give you a list of the plugins available to enable:
 
-    [ ] protobuffs                0.6.0
-    [ ] rabbit_exchange_type_riak 0.1.8
-    [ ] riakc                     1.2.1
+    [ ] protobuffs                0.7.0
+    [ ] rabbit_exchange_type_riak 0.1.9
+    [ ] riak_pb                   1.2.0	
+    [ ] riakc                     1.3.1
 
 Enable the plugin (including dependencies) by executing:
 
@@ -48,9 +49,10 @@ Enable the plugin (including dependencies) by executing:
   
 If you run `list` again, you should see them enabled:
 
-    [e] protobuffs                0.6.0
-    [E] rabbit_exchange_type_riak 0.1.8
-    [e] riakc                     1.2.1
+   [e] protobuffs                        0.7.0
+   [E] rabbit_exchange_type_riak         0.1.9
+   [e] riak_pb                           1.2.0
+   [e] riakc                             1.3.1
 
 *NOTE:* I've also put up a tar file of the required .ez files you need to install in your RabbitMQ's plugins directory.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {
   deps, [
-    {rabbit_common, ".*", {git, "https://github.com/jbrisbin/rabbit_common.git", {tag, "rabbitmq-2.8.1"}}},
-    {riakc, ".*", {git, "https://github.com/basho/riak-erlang-client.git", {tag, "1.2.1"}}}
+    {rabbit_common, ".*", {git, "https://github.com/bkearns/rabbit_common.git", {tag, "master"}}},
+    {riakc, ".*", {git, "https://github.com/basho/riak-erlang-client.git", {tag, "1.3.1"}}}
   ]
 }.

--- a/src/rabbit_exchange_type_riak.app.src
+++ b/src/rabbit_exchange_type_riak.app.src
@@ -1,7 +1,7 @@
 {application, rabbit_exchange_type_riak,
  [
   {description, "RabbitMQ Riak Exchange Plugin"},
-  {vsn, "0.1.8"},
+  {vsn, "0.1.9"},
   {modules, []},
   {registered, []},
   {env, []},


### PR DESCRIPTION
Thanks for putting this together.  I updated this to use 3.0.0 and to not require a content-type header.  It also requires a pull of my fork of your rabbitmq_common that I've updated to 3.0.0.

-b
